### PR TITLE
Implement supply chain queries

### DIFF
--- a/src/PharmaceuticalChain.API/Controllers/Models/Queries/BatchSupplyChainQueryData.cs
+++ b/src/PharmaceuticalChain.API/Controllers/Models/Queries/BatchSupplyChainQueryData.cs
@@ -7,9 +7,14 @@ namespace PharmaceuticalChain.API.Controllers.Models.Queries
 {
     public class BatchSupplyChainQueryData
     {
-        public uint TotalTenants { get; set; }
-        public uint TotalTransfers { get; set; }
+        public uint TotalTenants { get; set; } = 0;
+        public uint TotalTransfers { get; set; } = 0;
 
-        public List<List<MedicineBatchTransferQueryData>> TransferChains { get; set; }
+        public List<MedicineBatchTransferQueryData> Transfers { get; set; }
+
+        public BatchSupplyChainQueryData()
+        {
+            Transfers = new List<MedicineBatchTransferQueryData>();
+        }
     }
 }

--- a/src/PharmaceuticalChain.API/Controllers/Models/Queries/BatchSupplyChainQueryData.cs
+++ b/src/PharmaceuticalChain.API/Controllers/Models/Queries/BatchSupplyChainQueryData.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PharmaceuticalChain.API.Controllers.Models.Queries
+{
+    public class BatchSupplyChainQueryData
+    {
+        public uint TotalTenants { get; set; }
+        public uint TotalTransfers { get; set; }
+
+        public List<List<MedicineBatchTransferQueryData>> TransferChains { get; set; }
+    }
+}

--- a/src/PharmaceuticalChain.API/Controllers/Models/Queries/DetailedBatchSupplyChainQueryData.cs
+++ b/src/PharmaceuticalChain.API/Controllers/Models/Queries/DetailedBatchSupplyChainQueryData.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PharmaceuticalChain.API.Controllers.Models.Queries
+{
+    public class DetailedBatchSupplyChainQueryData
+    {
+        public uint TotalTenants { get; set; }
+        public uint TotalTransfers { get; set; }
+
+        public List<List<MedicineBatchTransferQueryData>> TransferChains { get; set; }
+    }
+}

--- a/src/PharmaceuticalChain.API/Controllers/SupplyChainsController.cs
+++ b/src/PharmaceuticalChain.API/Controllers/SupplyChainsController.cs
@@ -20,6 +20,18 @@ namespace PharmaceuticalChain.API.Controllers
             this.supplyChainService = supplyChainService;
         }
 
+        /// <summary>
+        /// Get supply chain for a medicine batch.
+        /// This API supports 2 types of data format right now:
+        ///     - The simple (Recommended): In theory, provide nodes (Tenants) and edges (Transfers) of the supply chain. Using these information, a client can then draw a supply chain.
+        ///     - The detailed: (Still in progress) Split the supply chain into separated chains from manufacturer to the last tenant.
+        /// </summary>
+        /// <param name="batchId"></param>
+        /// <param name="isDetailed">
+        ///     Specify `false` or don't pass this query to use the simple query. (RECOMMENDED)
+        ///     Specify `true` to use a detailed query.
+        /// </param>
+        /// <returns></returns>
         [HttpGet("{batchId}")]
         public IActionResult GetSupplyChain(Guid batchId, [FromQuery]bool? isDetailed)
         {

--- a/src/PharmaceuticalChain.API/Controllers/SupplyChainsController.cs
+++ b/src/PharmaceuticalChain.API/Controllers/SupplyChainsController.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using PharmaceuticalChain.API.Controllers.Models.Queries;
+using PharmaceuticalChain.API.Services.Interfaces;
+
+namespace PharmaceuticalChain.API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class SupplyChainsController : ControllerBase
+    {
+        private readonly ISupplyChainService supplyChainService;
+        public SupplyChainsController(
+            ISupplyChainService supplyChainService)
+        {
+            this.supplyChainService = supplyChainService;
+        }
+
+        [HttpGet("{batchId}")]
+        public IActionResult GetSupplyChain(Guid batchId)
+        {
+            try
+            {
+                BatchSupplyChainQueryData result = supplyChainService.GetBatchSupplyChain(batchId);
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, ex);
+            }
+        }
+    }
+}

--- a/src/PharmaceuticalChain.API/Controllers/SupplyChainsController.cs
+++ b/src/PharmaceuticalChain.API/Controllers/SupplyChainsController.cs
@@ -21,12 +21,20 @@ namespace PharmaceuticalChain.API.Controllers
         }
 
         [HttpGet("{batchId}")]
-        public IActionResult GetSupplyChain(Guid batchId)
+        public IActionResult GetSupplyChain(Guid batchId, [FromQuery]bool? isDetailed)
         {
             try
             {
-                BatchSupplyChainQueryData result = supplyChainService.GetBatchSupplyChain(batchId);
-                return Ok(result);
+                if (isDetailed.HasValue && isDetailed.Value == true)
+                {
+                    DetailedBatchSupplyChainQueryData result = supplyChainService.GetDetailedBatchSupplyChain(batchId);
+                    return Ok(result);
+                }
+                else
+                {
+                    BatchSupplyChainQueryData result = supplyChainService.GetSimpleBatchSupplyChain(batchId);
+                    return Ok(result);
+                }
             }
             catch (Exception ex)
             {

--- a/src/PharmaceuticalChain.API/Models/Database/Medicine.cs
+++ b/src/PharmaceuticalChain.API/Models/Database/Medicine.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 namespace PharmaceuticalChain.API.Models.Database
 {
+    [Newtonsoft.Json.JsonObject(IsReference = true)]
     public class Medicine : BlockchainObject
     {
         [Key]

--- a/src/PharmaceuticalChain.API/PharmaceuticalChain.API.xml
+++ b/src/PharmaceuticalChain.API/PharmaceuticalChain.API.xml
@@ -17,6 +17,20 @@
             </summary>
             <returns>Return information about a medicine on the network.</returns>
         </member>
+        <member name="M:PharmaceuticalChain.API.Controllers.SupplyChainsController.GetSupplyChain(System.Guid,System.Nullable{System.Boolean})">
+            <summary>
+            Get supply chain for a medicine batch.
+            This API supports 2 types of data format right now:\n
+                - The simple (Recommended): In theory, provide nodes (Tenants) and edges (Transfers) of the supply chain. Using these information, a client can then draw a supply chain.
+                - The detailed: (Still in progress) Split the supply chain into separated chains from manufacturer to the last tenant.
+            </summary>
+            <param name="batchId"></param>
+            <param name="isDetailed">
+                Specify `false` or don't pass this query to use the simple query. (RECOMMENDED)
+                Specify `true` to use a detailed query.
+            </param>
+            <returns></returns>
+        </member>
         <member name="M:PharmaceuticalChain.API.Controllers.TenantsController.CreateTenantAsync(PharmaceuticalChain.API.Controllers.Models.Commands.CreateTenantCommand)">
             <summary>
             Send a transaction to create a new tenant on the Ethereum network.

--- a/src/PharmaceuticalChain.API/Services/BackgroundJobs/Implementations/TenantBackgroundJob.cs
+++ b/src/PharmaceuticalChain.API/Services/BackgroundJobs/Implementations/TenantBackgroundJob.cs
@@ -33,23 +33,23 @@ namespace PharmaceuticalChain.API.Services.BackgroundJobs.Implementations
 
         void ITenantBackgroundJob.SyncDatabaseWithBlockchain()
         {
-            var allTenants = tenantRepository.GetAll();
+            //var allTenants = tenantRepository.GetAll();
 
-            // Sync contract address
-            var tenantNotHaveContractAddressList = allTenants.Where(t => t.ContractAddress == null).ToList();
-            foreach (var tenantNotHaveContractAddress in tenantNotHaveContractAddressList)
-            {
-                var receipt = ethereumService.GetTransactionReceipt(tenantNotHaveContractAddress.TransactionHash).Result;
-                if (receipt == null)
-                    return;
-                if (receipt.Status.Value == (new HexBigInteger(1)).Value)
-                {
-                    var contractAddress = tenantService.GetContractAddress(tenantNotHaveContractAddress.Id).Result;
-                    tenantNotHaveContractAddress.ContractAddress = contractAddress;
-                    tenantNotHaveContractAddress.TransactionStatus = Models.Database.TransactionStatuses.Success;
-                    tenantRepository.Update(tenantNotHaveContractAddress);
-                }
-            }
+            //// Sync contract address
+            //var tenantNotHaveContractAddressList = allTenants.Where(t => t.ContractAddress == null).ToList();
+            //foreach (var tenantNotHaveContractAddress in tenantNotHaveContractAddressList)
+            //{
+            //    var receipt = ethereumService.GetTransactionReceipt(tenantNotHaveContractAddress.TransactionHash).Result;
+            //    if (receipt == null)
+            //        return;
+            //    if (receipt.Status.Value == (new HexBigInteger(1)).Value)
+            //    {
+            //        var contractAddress = tenantService.GetContractAddress(tenantNotHaveContractAddress.Id).Result;
+            //        tenantNotHaveContractAddress.ContractAddress = contractAddress;
+            //        tenantNotHaveContractAddress.TransactionStatus = Models.Database.TransactionStatuses.Success;
+            //        tenantRepository.Update(tenantNotHaveContractAddress);
+            //    }
+            //}
         }
 
         void ITenantBackgroundJob.WaitForTransactionToSuccessThenFinishCreatingTenant(Tenant tenant)

--- a/src/PharmaceuticalChain.API/Services/Implementations/SupplyChainService.cs
+++ b/src/PharmaceuticalChain.API/Services/Implementations/SupplyChainService.cs
@@ -37,6 +37,7 @@ namespace PharmaceuticalChain.API.Services.Implementations
                 .ToList();
 
             result.TransferChains = new List<List<MedicineBatchTransferQueryData>>();
+
             // Trace backwards
             foreach (var transfer in lastTierTransfers)
             {
@@ -55,6 +56,7 @@ namespace PharmaceuticalChain.API.Services.Implementations
 
                 result.TransferChains.Add(transferChain);
             }
+            // TODO: Trace tier backwards. There might be missing chains in which transfers have lower tier than the highest one of the whole batch supply chain.
 
             // Calculate the summary section
             var tempTransfers = new List<MedicineBatchTransferQueryData>();

--- a/src/PharmaceuticalChain.API/Services/Implementations/SupplyChainService.cs
+++ b/src/PharmaceuticalChain.API/Services/Implementations/SupplyChainService.cs
@@ -1,0 +1,65 @@
+﻿using PharmaceuticalChain.API.Controllers.Models.Queries;
+using PharmaceuticalChain.API.Models.Database;
+using PharmaceuticalChain.API.Repositories.Interfaces;
+using PharmaceuticalChain.API.Services.Interfaces;
+using PharmaceuticalChain.API.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PharmaceuticalChain.API.Services.Implementations
+{
+    public class SupplyChainService : ISupplyChainService
+    {
+        private readonly IMedicineBatchRepository medicineBatchRepository;
+        private readonly IMedicineBatchTransferRepository medicineBatchTransferRepository;
+        public SupplyChainService(
+            IMedicineBatchRepository medicineBatchRepository,
+            IMedicineBatchTransferRepository medicineBatchTransferRepository)
+        {
+            this.medicineBatchRepository = medicineBatchRepository;
+            this.medicineBatchTransferRepository = medicineBatchTransferRepository;
+        }
+
+        BatchSupplyChainQueryData ISupplyChainService.GetBatchSupplyChain(Guid batchId)
+        {
+            var result = new BatchSupplyChainQueryData();
+
+            var transfersOfThatBatch = medicineBatchTransferRepository.GetAll()
+                .Where(t => t.MedicineBatchId == batchId)
+                .ToList();
+
+            // Get all last tier transfers
+            var higestTier = transfersOfThatBatch.Max(t => t.Tier);
+            List<MedicineBatchTransfer> lastTierTransfers = transfersOfThatBatch
+                .Where(t => t.Tier == higestTier)
+                .ToList();
+
+            result.TransferChains = new List<List<MedicineBatchTransferQueryData>>();
+            // Trace backwards
+            foreach (var transfer in lastTierTransfers)
+            {
+                List<MedicineBatchTransferQueryData> transferChain = new List<MedicineBatchTransferQueryData>();
+                var iterator = transfer;
+                var transferPool = transfersOfThatBatch;
+                bool parentMatchCondition(MedicineBatchTransfer t) => t.ToId == iterator.FromId;
+
+                transferChain.Add(iterator.ToMedicineBatchTransferQueryData());
+
+                while (iterator.HasParent(transferPool, parentMatchCondition))
+                {
+                    iterator = iterator.Parent(transferPool, parentMatchCondition).Single();
+                    transferChain.Add(iterator.ToMedicineBatchTransferQueryData());
+                }
+
+                result.TransferChains.Add(transferChain);
+            }
+
+            // Finalize the result
+            
+
+            return result;
+        }
+    }
+}

--- a/src/PharmaceuticalChain.API/Services/Interfaces/ISupplyChainService.cs
+++ b/src/PharmaceuticalChain.API/Services/Interfaces/ISupplyChainService.cs
@@ -1,0 +1,13 @@
+﻿using PharmaceuticalChain.API.Controllers.Models.Queries;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PharmaceuticalChain.API.Services.Interfaces
+{
+    public interface ISupplyChainService
+    {
+        BatchSupplyChainQueryData GetBatchSupplyChain(Guid batchId);
+    }
+}

--- a/src/PharmaceuticalChain.API/Services/Interfaces/ISupplyChainService.cs
+++ b/src/PharmaceuticalChain.API/Services/Interfaces/ISupplyChainService.cs
@@ -8,6 +8,7 @@ namespace PharmaceuticalChain.API.Services.Interfaces
 {
     public interface ISupplyChainService
     {
-        BatchSupplyChainQueryData GetBatchSupplyChain(Guid batchId);
+        DetailedBatchSupplyChainQueryData GetDetailedBatchSupplyChain(Guid batchId);
+        BatchSupplyChainQueryData GetSimpleBatchSupplyChain(Guid batchId);
     }
 }

--- a/src/PharmaceuticalChain.API/Startup.cs
+++ b/src/PharmaceuticalChain.API/Startup.cs
@@ -59,6 +59,8 @@ namespace PharmaceuticalChain.API
 
             services.AddTransient<IAuth0Service, Auth0Service>();
 
+            services.AddTransient<ISupplyChainService, SupplyChainService>();
+
             services.AddTransient<ITenantService, TenantService>();
             services.AddTransient<IDrugTransactionService, DrugTransactionService>();
             services.AddTransient<IMedicineService, MedicineService>();

--- a/src/PharmaceuticalChain.API/appsettings.json
+++ b/src/PharmaceuticalChain.API/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=.;Database=PharmaChain;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=.\\LAM;Database=PharmaChain;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Get supply chain for a medicine batch.

This API supports 2 types of data format right now:

- **The simple (Recommended):** In theory, provide nodes (Tenants) and edges (Transfers) of the supply chain. Using these information, a client can then draw a supply chain.
- The detailed: (Still in progress) Split the supply chain into separated chains from manufacturer to the last tenant.

Example call (with the recommended algorithm):

```
https://localhost:5001/api/SupplyChains/8e89baee-db0f-4b22-e7f5-08d76cced29c?isDetailed=false
```
